### PR TITLE
Ref/module names

### DIFF
--- a/iodispatcher/Makefile
+++ b/iodispatcher/Makefile
@@ -1,3 +1,3 @@
 # Object files and module definition
-obj-m += iodispatcher.o
+obj-m += bao-iodispatcher.o
 iodispatcher-y := dm.o driver.o intc.o io_client.o io_dispatcher.o ioctls.o ioeventfd.o irqfd.o

--- a/iodispatcher/irqfd.c
+++ b/iodispatcher/irqfd.c
@@ -182,13 +182,13 @@ static int bao_irqfd_assign(struct bao_dm* dm, struct bao_irqfd* args)
 
     // get a reference to the file descriptor
     f = fdget(args->fd);
-    if (!f.file) {
+    if (!fd_file(f)) {
         ret = -EBADF;
         goto out;
     }
 
     // get the eventfd from the file descriptor
-    eventfd = eventfd_ctx_fileget(f.file);
+    eventfd = eventfd_ctx_fileget(fd_file(f));
     if (IS_ERR(eventfd)) {
         ret = PTR_ERR(eventfd);
         goto fail;
@@ -223,7 +223,7 @@ static int bao_irqfd_assign(struct bao_dm* dm, struct bao_irqfd* args)
     // (this function will internally call the custom poll function already
     // defined) any event signaled upon this stage will be handled by the custom
     // poll function
-    events = vfs_poll(f.file, &irqfd->pt);
+    events = vfs_poll(fd_file(f), &irqfd->pt);
 
     // if the event is signaled, signal Bao Hypervisor
     if (events & EPOLLIN) {

--- a/ipc/Makefile
+++ b/ipc/Makefile
@@ -1,3 +1,3 @@
 # Object files and module definition
-obj-m += ipc.o
+obj-m += bao-ipc.o
 ipc-y := ipcshmem.o


### PR DESCRIPTION
This will make the names of the generated .ko modules more clearly as part of bao infrastructure.